### PR TITLE
Added Gess1t't Proxy API

### DIFF
--- a/Repository/0.5.2.0/Gess1t/Gess1tsProxyAPI/ProxyAPI/1.0.0.json
+++ b/Repository/0.5.2.0/Gess1t/Gess1tsProxyAPI/ProxyAPI/1.0.0.json
@@ -1,7 +1,7 @@
 {
     "Name": "Gess1t's Proxy API",
     "Owner": "Gess1t",
-    "Description": "Interact will plugins, Make Overlays and more.",
+    "Description": "Proxy library for external utilities.",
     "PluginVersion": "1.0.0",
     "SupportedDriverVersion": "0.5.2.0",
     "RepositoryUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API",

--- a/Repository/0.5.2.0/Gess1t/Gess1tsProxyAPI/ProxyAPI/1.0.0.json
+++ b/Repository/0.5.2.0/Gess1t/Gess1tsProxyAPI/ProxyAPI/1.0.0.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Gess1t's Proxy API",
+    "Owner": "Gess1t",
+    "Description": "Interact will plugins, Make Overlays and more.",
+    "PluginVersion": "1.0.0",
+    "SupportedDriverVersion": "0.5.2.0",
+    "RepositoryUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API",
+    "DownloadUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API/releases/download/1.0.0/Proxy.API.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "9ff731e487181f8f831f16b88f648a70a49533dc2f5f2f8f7fb5a6ecb7a2d473",
+    "WikiUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API",
+    "LicenseIdentifier": "GPL-3.0-only"
+}

--- a/Repository/0.5.2.0/Gess1t/Gess1tsProxyAPI/ProxyAPI/1.0.1.json
+++ b/Repository/0.5.2.0/Gess1t/Gess1tsProxyAPI/ProxyAPI/1.0.1.json
@@ -2,12 +2,12 @@
     "Name": "Gess1t's Proxy API",
     "Owner": "Gess1t",
     "Description": "Proxy library for external utilities.",
-    "PluginVersion": "1.0.0",
+    "PluginVersion": "1.0.1",
     "SupportedDriverVersion": "0.5.2.0",
     "RepositoryUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API",
-    "DownloadUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API/releases/download/1.0.0/Proxy.API.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API/releases/download/1.0.1/Proxy.API.zip",
     "CompressionFormat": "zip",
-    "SHA256": "9ff731e487181f8f831f16b88f648a70a49533dc2f5f2f8f7fb5a6ecb7a2d473",
+    "SHA256": "6e1d2f21d97293f611465510cb9673d6170555e692a51abbadba7c78eabb94e7",
     "WikiUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
Allow communication between a web interface and filters / interpolators.

Requirement for the following plugins with overlays:
- [Gess1t's Area Randomizer](https://github.com/Mrcubix/Gess1t-s-Area-Randomizer)
- [Gess1t's Area Visualizer](https://github.com/Mrcubix/Area-Visualizer-Overlay)