### PR TITLE
Update OTD.Backport to 1.0.2

### DIFF
--- a/Repository/0.5.2.0/Gess1t/OTD.Backport/OTD.Backport/1.0.2.json
+++ b/Repository/0.5.2.0/Gess1t/OTD.Backport/OTD.Backport/1.0.2.json
@@ -2,12 +2,12 @@
     "Name": "OTD.Backport",
     "Owner": "Gess1t",
     "Description": "Backport changes made after OTD 0.5.3's release that are compatible with 0.5.2 up to 0.5.3.3",
-    "PluginVersion": "1.0.1",
+    "PluginVersion": "1.0.2",
     "SupportedDriverVersion": "0.5.2",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.Backport/",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.Backport/releases/download/1.0.1/OTD.Backport.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.Backport/releases/download/1.0.2/OTD.Backport.zip",
     "CompressionFormat": "zip",
-    "SHA256": "86bd9688296b463c9aaf33194fcd326e432c5bd3f8e0a03b76a7970837ddf7a1",
+    "SHA256": "55f61bfa1b2d14ea43e544b9e9131a3e4704b79f9232672ecdcccc45d4833d1c",
     "WikiUrl": "https://github.com/Mrcubix/OTD.Backport/",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.5.2.0/Gess1t/OTD.Backport/OTD.Backport/1.0.2.json
+++ b/Repository/0.5.2.0/Gess1t/OTD.Backport/OTD.Backport/1.0.2.json
@@ -8,6 +8,6 @@
     "DownloadUrl": "https://github.com/Mrcubix/OTD.Backport/releases/download/1.0.2/OTD.Backport.zip",
     "CompressionFormat": "zip",
     "SHA256": "55f61bfa1b2d14ea43e544b9e9131a3e4704b79f9232672ecdcccc45d4833d1c",
-    "WikiUrl": "https://github.com/Mrcubix/OTD.Backport/",
+    "WikiUrl": "https://mrcubix.github.io/OTD.Backport-Wiki/",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
# Changes: 

- Fix XP-Pen Deco 01 V2 parser
- Fix CTH 460 being somehow having the same content but being different byte wise which was causing issues