### PR TITLE
Add Cycle Keybind plugin

### DIFF
--- a/Repository/0.6.3.0/Ashesh3/CycleBind/CycleBind.json
+++ b/Repository/0.6.3.0/Ashesh3/CycleBind/CycleBind.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Cycle Keybind",
+    "Owner": "Ashesh3",
+    "Description": "Cycle multiple keyboard bindings on each press.",
+    "PluginVersion": "0.1.0.0",
+    "SupportedDriverVersion": "0.6.3.0",
+    "RepositoryUrl": "https://github.com/Ashesh3/OTDCycleBind",
+    "DownloadUrl": "https://github.com/Ashesh3/OTDCycleBind/releases/download/1.0.0/CycleBind.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "7ddfb5dd4080c0b23629047639f8c398f4fe1b38897b369a680be68a8a97eabc",
+    "WikiUrl": "https://github.com/Ashesh3/OTDCycleBind/blob/master/README.md",
+    "LicenseIdentifier": "MIT"
+}


### PR DESCRIPTION
The Cycle Bind plugin for OpenTabletDriver offers users an enhanced key binding experience by allowing them to set multiple keys to be pressed in a sequential cycle. Users can easily input their desired key combinations in the format "A+B+C+...", and the plugin will handle the cycling of key presses.