### PR TITLE
Update TemporalResampler to v1.1.2

### DIFF
--- a/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
+++ b/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Temporal Resampler",
+    "Owner": "shmkle",
+    "Description": "Input resampler for higher hz monitors.",
+    "PluginVersion": "1.1.1",
+    "SupportedDriverVersion": "0.6.4.0",
+    "RepositoryUrl": "https://github.com/shmkle/TemporalResampler",
+    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.1.1/TemporalResampler.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "c5a6c605c384f512a18a756eb50496312b8111ab5495568176b5d77445b9bdb3",
+    "WikiUrl": "https://github.com/shmkle/TemporalResampler/blob/main/README.md",
+    "LicenseIdentifier": "GPL-3.0-only"
+}

--- a/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
+++ b/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
@@ -2,12 +2,12 @@
     "Name": "Temporal Resampler",
     "Owner": "shmkle",
     "Description": "Input resampler for higher hz monitors.",
-    "PluginVersion": "1.1.1",
+    "PluginVersion": "1.1.2",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/shmkle/TemporalResampler",
-    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.1.1/TemporalResampler.zip",
+    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.1.2/TemporalResampler.zip",
     "CompressionFormat": "zip",
-    "SHA256": "c5a6c605c384f512a18a756eb50496312b8111ab5495568176b5d77445b9bdb3",
+    "SHA256": "ed5397aa96e3c36c47699a677ad748617167f06752699a22e49e30ec7fc980d1",
     "WikiUrl": "https://github.com/shmkle/TemporalResampler/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
*v1.1.1 - v1.1.2

Improved value input intuitiveness in an attempt to make the filter easier to understand
Removed Frame Time Sync value

*v1.1.0 - v1.1.1

Added Frame Time Sync value
Added limits to values
Changed chatter diameter acceleration calculation


*v1.1.0 (since the last OTD plugin repository update)

Fixed Hover Distance Limiter filter interaction with relative mode 
Added a new approach to extrapolating inputs when using Chatter Diameter 
Added Chatter Diameter value
Further improved output clarity