### PR TITLE
Adding Back plugins, as well as new ones

### DIFF
--- a/Repository/0.5.2.0/Gess1t/Gess1tsAreaRandomizer/Gess1tsAreaRandomizer.json
+++ b/Repository/0.5.2.0/Gess1t/Gess1tsAreaRandomizer/Gess1tsAreaRandomizer.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Gess1t's Area Randomizer",
+    "Owner": "Gess1t",
+    "Description": "Generate a random area / sensitivity while using OTD",
+    "PluginVersion": "1.1.2",
+    "SupportedDriverVersion": "0.5.2.0",
+    "RepositoryUrl": "https://github.com/Mrcubix/Gess1t-s-Area-Randomizer/",
+    "DownloadUrl": "https://github.com/Mrcubix/Gess1t-s-Area-Randomizer/releases/download/1.1.2/Gess1t.s.Area.Randomizer.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "dac5aa5e3245cbbd554c4b81f64675af1347b43f25b9a78a5d8edf0ff4d6f0dd",
+    "WikiUrl": "https://github.com/Mrcubix/Gess1t-s-Area-Randomizer",
+    "LicenseIdentifier": "GPL-3.0-only"
+}

--- a/Repository/0.5.2.0/Gess1t/Gess1tsProxyAPI/Gess1tsProxyAPI.json
+++ b/Repository/0.5.2.0/Gess1t/Gess1tsProxyAPI/Gess1tsProxyAPI.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Gess1t's Proxy API",
+    "Owner": "Gess1t",
+    "Description": "Proxy library for external utilities.",
+    "PluginVersion": "1.0.1",
+    "SupportedDriverVersion": "0.5.2.0",
+    "RepositoryUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API",
+    "DownloadUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API/releases/download/1.0.1/Proxy.API.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "6e1d2f21d97293f611465510cb9673d6170555e692a51abbadba7c78eabb94e7",
+    "WikiUrl": "https://github.com/Mrcubix/Gess1t-s-Proxy-API",
+    "LicenseIdentifier": "GPL-3.0-only"
+}

--- a/Repository/0.5.2.0/Gess1t/OTD.Backport/OTD.Backport.json
+++ b/Repository/0.5.2.0/Gess1t/OTD.Backport/OTD.Backport.json
@@ -1,0 +1,13 @@
+{
+    "Name": "OTD.Backport",
+    "Owner": "Gess1t",
+    "Description": "Backport changes made after OTD 0.5.3's release that are compatible with 0.5.2 up to 0.5.3.3",
+    "PluginVersion": "1.0.6",
+    "SupportedDriverVersion": "0.5.2",
+    "RepositoryUrl": "https://github.com/Mrcubix/OTD.Backport/",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.Backport/releases/download/1.0.6/OTD.Backport.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "f1991b6fd9379c3d2614315f661aef6046aac747ec1829f187a9352f27a30d09",
+    "WikiUrl": "https://mrcubix.github.io/OTD.Backport-Wiki/",
+    "LicenseIdentifier": "GPL-3.0-only"
+}

--- a/Repository/0.5.3.1/Gess1t/Additional-Keys/Additional-Keys.json
+++ b/Repository/0.5.3.1/Gess1t/Additional-Keys/Additional-Keys.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Additional Keys",
+    "Owner": "Gess1t",
+    "Description": "Allow for the use of additional Fxx & Media keys",
+    "PluginVersion": "1.0.0",
+    "SupportedDriverVersion": "0.5.3.1",
+    "RepositoryUrl": "https://github.com/Mrcubix/Additional-Keys",
+    "DownloadUrl": "https://github.com/Mrcubix/Additional-Keys/releases/download/1.0.0/Additional-Keys-0.5.x-1.0.0.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "de2b48eaad2b0ef8e7c8a25bf17a0971c0efca9c510d3ea1349416f5d09782cd",
+    "WikiUrl": "https://github.com/Mrcubix/Additional-Keys",
+    "LicenseIdentifier": "GPL-3.0-only"
+}

--- a/Repository/0.5.3.1/Gess1t/WheelAddon/WheelAddon.json
+++ b/Repository/0.5.3.1/Gess1t/WheelAddon/WheelAddon.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Wheel Addon",
+    "Owner": "Gess1t",
+    "Description": "Add support for the touch wheel on wacom tablets (SEE REPO FOR EXTRA DEPENDENCIES)",
+    "PluginVersion": "1.0.2",
+    "SupportedDriverVersion": "0.5.3.1",
+    "RepositoryUrl": "https://github.com/Mrcubix/WheelAddon",
+    "DownloadUrl": "https://github.com/Mrcubix/WheelAddon/releases/download/1.0.2-re/Wheel-Addon.Installer.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "048ea558f2d9cbcd77a62704a7cf43c29f9a77d6d9db99a19a26a72256c87ec3",
+    "WikiUrl": "https://github.com/Mrcubix/WheelAddon",
+    "LicenseIdentifier": "MIT"
+}

--- a/Repository/0.5.3.3/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
+++ b/Repository/0.5.3.3/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Enhanced Output Mode",
+    "Owner": "Gess1t",
+    "Description": "Enhanced Output Mode for OpenTabletDriver (Touch Support, Windows Onk & VMulti support, plugin report access, ...)",
+    "PluginVersion": "1.0.8",
+    "SupportedDriverVersion": "0.5.3.3",
+    "RepositoryUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.0.8/OTD.EnhancedOutputMode-0.5.x.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "062f464b875288dd609121152ecdc8109d8eb8aa895686597921ae0e838cf838",
+    "WikiUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
+    "LicenseIdentifier": "GPL-3.0-only"
+}

--- a/Repository/0.5.3.3/Gess1t/OTD.LEDSanbox/OTD.LEDSanbox.json
+++ b/Repository/0.5.3.3/Gess1t/OTD.LEDSanbox/OTD.LEDSanbox.json
@@ -1,0 +1,13 @@
+{
+    "Name": "LED Sandbox",
+    "Owner": "Gess1t",
+    "Description": "allow users to use images of 64x128 resolution and show them on any of the 2 LED display contained within Wacom PTK-x40 tablets.",
+    "PluginVersion": "1.0.3",
+    "SupportedDriverVersion": "0.5.3.3",
+    "RepositoryUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.LEDSandbox/releases/download/1.0.3-0.5.x/OTD.LEDSandbox-x86-0.5.x.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "cc305cf71cbe8150775852ea9044a7056b5d35959bd359d5c21e35504b21650b",
+    "WikiUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
+    "LicenseIdentifier": "MIT"
+}

--- a/Repository/0.6.0.2/Gess1t/Preset.Binding/Preset.Binding.json
+++ b/Repository/0.6.0.2/Gess1t/Preset.Binding/Preset.Binding.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Preset Binding",
+    "Owner": "Gess1t",
+    "Description": "Bind Presets to Keys",
+    "PluginVersion": "1.0.0",
+    "SupportedDriverVersion": "0.6.0.4",
+    "RepositoryUrl": "https://github.com/Mrcubix/Preset.Binding",
+    "DownloadUrl": "https://github.com/Mrcubix/Preset.Binding/releases/download/1.0.0/Preset.Binding.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "3e175cb6574cfd0f7d4b55f6a9b22114065042350f63b0bd48aa0c5048bdb1e0",
+    "WikiUrl": "https://github.com/Mrcubix/Preset.Binding",
+    "LicenseIdentifier": "MIT"
+}

--- a/Repository/0.6.0.3/Gess1t/Additional-Keys/Additional-Keys.json
+++ b/Repository/0.6.0.3/Gess1t/Additional-Keys/Additional-Keys.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Additional Keys",
+    "Owner": "Gess1t",
+    "Description": "Allow for the use of additional Fxx & Media keys",
+    "PluginVersion": "1.0.0",
+    "SupportedDriverVersion": "0.6.0.3",
+    "RepositoryUrl": "https://github.com/Mrcubix/Additional-Keys",
+    "DownloadUrl": "https://github.com/Mrcubix/Additional-Keys/releases/download/1.0.0/Additional-Keys-0.6.x-1.0.0.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "74b6ea33910d789d43da279cb336fb7834830148f88b710d02635090de466dd3",
+    "WikiUrl": "https://github.com/Mrcubix/Additional-Keys",
+    "LicenseIdentifier": "GPL-3.0-only"
+}

--- a/Repository/0.6.0.3/Gess1t/Preset.Binding/Preset.Binding.json
+++ b/Repository/0.6.0.3/Gess1t/Preset.Binding/Preset.Binding.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Preset Bindings",
+    "Owner": "Gess1t",
+    "Description": "A plugin for OTD 0.6.x to bind preset to tablet keys",
+    "PluginVersion": "1.0.0",
+    "SupportedDriverVersion": "0.6.0.3",
+    "RepositoryUrl": "https://github.com/Mrcubix/Preset.Binding",
+    "DownloadUrl": "https://github.com/Mrcubix/Preset.Binding/releases/download/1.0.0/Preset.Binding.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "3e175cb6574cfd0f7d4b55f6a9b22114065042350f63b0bd48aa0c5048bdb1e0",
+    "WikiUrl": "https://github.com/Mrcubix/Preset.Binding",
+    "LicenseIdentifier": "MIT"
+}

--- a/Repository/0.6.4.0/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
+++ b/Repository/0.6.4.0/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Enhanced Output Mode",
+    "Owner": "Gess1t",
+    "Description": "Enhanced Output Mode for OpenTabletDriver (Touch Support, Windows Onk & VMulti support, ...)",
+    "PluginVersion": "1.0.8",
+    "SupportedDriverVersion": "0.6.4.0",
+    "RepositoryUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/PRE-1.0.8-0.6.x/OTD.EnhancedOutputMode-0.6.x.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "d8e98418802b7ccd32cfb9aca04d0d10ae783e74826813e5020e776fc0f30094",
+    "WikiUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
+    "LicenseIdentifier": "GPL-3.0-only"
+}

--- a/Repository/0.6.4.0/Gess1t/OTD.LEDSanbox/OTD.LEDSanbox.json
+++ b/Repository/0.6.4.0/Gess1t/OTD.LEDSanbox/OTD.LEDSanbox.json
@@ -1,0 +1,13 @@
+{
+    "Name": "LED Sandbox",
+    "Owner": "Gess1t",
+    "Description": "allow users to use images of 64x128 resolution and show them on any of the 2 LED display contained within Wacom PTK-x40 tablets.",
+    "PluginVersion": "1.0.3",
+    "SupportedDriverVersion": "0.6.4.0",
+    "RepositoryUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.LEDSandbox/releases/download/1.0.3/OTD.LEDSandbox-x86-0.6.x.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "8c9ab56895518048e2d4102e762d0b5c8872db826ba2201aed56eb2bc596aef9",
+    "WikiUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
+    "LicenseIdentifier": "MIT"
+}


### PR DESCRIPTION
## I'm back

I'm bringing back some plugins, as well as adding new ones.

## The List

- Proxy API for 0.5
- Area Randomizer for 0.5
- OTD.Backport for 0.5 (Dependency for OTD.EnhancedOutputMode & WheelAddon)
- OTD.EnhancedOutputMode (Enhanced output mode, adding support for report access, Touch Support & Aux Filters in 0.5, touch only in 0.6)
- WheelAddon for 0.5 (for now) (Support for the Touch Wheel of Wacom Tablets, bind functions to binding using an interface similar to OTD, but in Avalonia)
- Additional Keys for 0.5 & 0.6(Add new keys, such as F keys & media keys in their own categories)
- Preset.Binding for 0.6 (Finally, bind a tablet key to a specific preset of your choice!)

## Upcoming

- Wheel Addon for 0.6 (Should require the fewest amount of work, though will need to be tested),
- Native Touch Gestures (OTD.EnhancedOutputMode) Support for stuff such as natural scrolling & other,
- Custom Touch Gestures For 0.5 first, then 0.6, Bind OTD functions to simple touch gestures, such as a tap, a hold, a swipe or a pinch. (Tap & Hold up to 10 Contacts)