### PR TITLE
Update TemporalResampler to v1.2.4

### DIFF
--- a/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
+++ b/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
@@ -2,12 +2,12 @@
     "Name": "Temporal Resampler",
     "Owner": "shmkle",
     "Description": "Input resampler for higher hz monitors.",
-    "PluginVersion": "1.2.0",
+    "PluginVersion": "1.2.1",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/shmkle/TemporalResampler",
-    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.2.0/TemporalResampler.zip",
+    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.2.1/TemporalResampler.zip",
     "CompressionFormat": "zip",
-    "SHA256": "af123fb6f432952b00478acd31fa3f38f3ab34fae26276d68377cf52e2a757bb",
+    "SHA256": "82ba96a5140e0a06cedd684245b77ac186dad4e822b888d017f9f3e1c7bf676f",
     "WikiUrl": "https://github.com/shmkle/TemporalResampler/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
+++ b/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
@@ -2,12 +2,12 @@
     "Name": "Temporal Resampler",
     "Owner": "shmkle",
     "Description": "Input resampler for higher hz monitors.",
-    "PluginVersion": "1.2.1",
+    "PluginVersion": "1.2.2",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/shmkle/TemporalResampler",
-    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.2.1/TemporalResampler.zip",
+    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.2.2/TemporalResampler.zip",
     "CompressionFormat": "zip",
-    "SHA256": "82ba96a5140e0a06cedd684245b77ac186dad4e822b888d017f9f3e1c7bf676f",
+    "SHA256": "dccf8297e30a1fce463540570f41fb29169d3ab2aa426af8b7a5f95afe0c8fae",
     "WikiUrl": "https://github.com/shmkle/TemporalResampler/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
+++ b/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
@@ -2,12 +2,12 @@
     "Name": "Temporal Resampler",
     "Owner": "shmkle",
     "Description": "Input resampler for higher hz monitors.",
-    "PluginVersion": "1.2.2",
+    "PluginVersion": "1.2.3",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/shmkle/TemporalResampler",
-    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.2.2/TemporalResampler.zip",
+    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.2.3/TemporalResampler.zip",
     "CompressionFormat": "zip",
-    "SHA256": "dccf8297e30a1fce463540570f41fb29169d3ab2aa426af8b7a5f95afe0c8fae",
+    "SHA256": "4d6351130cf58e9fed0fd69ee3ba6af9879e09628cfa8401491bb31239646805",
     "WikiUrl": "https://github.com/shmkle/TemporalResampler/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
+++ b/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
@@ -2,12 +2,12 @@
     "Name": "Temporal Resampler",
     "Owner": "shmkle",
     "Description": "Input resampler for higher hz monitors.",
-    "PluginVersion": "1.1.2",
+    "PluginVersion": "1.2.0",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/shmkle/TemporalResampler",
-    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.1.2/TemporalResampler.zip",
+    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.2.0/TemporalResampler.zip",
     "CompressionFormat": "zip",
-    "SHA256": "ed5397aa96e3c36c47699a677ad748617167f06752699a22e49e30ec7fc980d1",
+    "SHA256": "af123fb6f432952b00478acd31fa3f38f3ab34fae26276d68377cf52e2a757bb",
     "WikiUrl": "https://github.com/shmkle/TemporalResampler/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
+++ b/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
@@ -2,12 +2,12 @@
     "Name": "Temporal Resampler",
     "Owner": "shmkle",
     "Description": "Input resampler for higher hz monitors.",
-    "PluginVersion": "1.2.3",
+    "PluginVersion": "1.2.4",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/shmkle/TemporalResampler",
-    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.2.3/TemporalResampler.zip",
+    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.2.4/TemporalResampler.zip",
     "CompressionFormat": "zip",
-    "SHA256": "4d6351130cf58e9fed0fd69ee3ba6af9879e09628cfa8401491bb31239646805",
+    "SHA256": "28d9aa48dc2102c9c7c313b2e60202d406a8b0550b053894dba8711997a441b5",
     "WikiUrl": "https://github.com/shmkle/TemporalResampler/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
- changed miscellaneous physics stuff, how "Chatter Diameter" is processed
- add "Maximize Frequency", and "Log Stats"
- renamed "Frame Time Shift" to "Prediction Ratio", "Chatter Diameter" to "Follow Radius"