### PR TITLE
Update OTD.EnhancedOutputMode & WheelAddon

### DIFF
--- a/Repository/0.5.3.3/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
+++ b/Repository/0.5.3.3/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
@@ -2,12 +2,12 @@
     "Name": "Enhanced Output Modes",
     "Owner": "Gess1t",
     "Description": "Enhanced Output Modes for OpenTabletDriver (Adds support for Touch Input, Plugin report access, ...)",
-    "PluginVersion": "1.0.8",
+    "PluginVersion": "1.1.1",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.0.8/OTD.EnhancedOutputMode-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.1/OTD.EnhancedOutputMode-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "062f464b875288dd609121152ecdc8109d8eb8aa895686597921ae0e838cf838",
+    "SHA256": "0bc72c774154704d2ceeba643ce1288213e9c7ad6a400755367110533dfd3d1f",
     "WikiUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.5.3.3/Gess1t/WheelAddon/WheelAddon.json
+++ b/Repository/0.5.3.3/Gess1t/WheelAddon/WheelAddon.json
@@ -2,12 +2,12 @@
     "Name": "Wheel Addon",
     "Owner": "Gess1t",
     "Description": "Add support for the touch wheel on wacom tablets (SEE REPO FOR EXTRA DEPENDENCIES)",
-    "PluginVersion": "1.0.2",
+    "PluginVersion": "1.0.7",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/WheelAddon",
-    "DownloadUrl": "https://github.com/Mrcubix/WheelAddon/releases/download/1.0.2-re/Wheel-Addon.Installer.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/WheelAddon/releases/download/1.0.7/Wheel-Addon.Installer.zip",
     "CompressionFormat": "zip",
-    "SHA256": "048ea558f2d9cbcd77a62704a7cf43c29f9a77d6d9db99a19a26a72256c87ec3",
+    "SHA256": "2b712ed1609e78e02dd89adf23e9d5f30571fabeec1fc58887b818027bd2f9a6",
     "WikiUrl": "https://github.com/Mrcubix/WheelAddon",
     "LicenseIdentifier": "MIT"
 }

--- a/Repository/0.6.4.0/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
+++ b/Repository/0.6.4.0/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
@@ -2,12 +2,12 @@
     "Name": "Enhanced Output Modes",
     "Owner": "Gess1t",
     "Description": "Enhanced Output Modes for OpenTabletDriver (Adds support for Touch Inputs)",
-    "PluginVersion": "1.0.8",
+    "PluginVersion": "1.1.2",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/PRE-1.0.8-0.6.x/OTD.EnhancedOutputMode-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.2-0.6.x/OTD.EnhancedOutputMode-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "d8e98418802b7ccd32cfb9aca04d0d10ae783e74826813e5020e776fc0f30094",
+    "SHA256": "a753285fe75333b292c5094d0203deabf0ae24b9fd6e065ac6535f4b329964e2",
     "WikiUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
Updated `OTD.EnhancedOutputMode` for both 0.5 & 0.6.

`OTD.EnhancedOutputMode` wasn't handling touch reports with no points, which in turn, caused issues in plugins relying on those, like my currently WIP Touch gesture plugin.

Speaking of which (out of context), is here a preview of the pan gesture i'm working on for those interested:

https://github.com/OpenTabletDriver/Plugin-Repository/assets/39861216/42691c64-25fa-49f1-922c-09a137998029

Anyways, some plugins also required to be initialized after the constructor as well as after the settings are injected,
so i added an interface for that purpose.

`WheelAddon` was also updated as it's dependent on `OTD.EnhancedOutputMode`.