### PR TITLE
Added back LED-Sandbox after Re-Release

### DIFF
--- a/Repository/0.5.3.3/Gess1t/OTD.LEDSandbox/OTD.LEDSandbox.json
+++ b/Repository/0.5.3.3/Gess1t/OTD.LEDSandbox/OTD.LEDSandbox.json
@@ -1,0 +1,13 @@
+{
+    "Name": "LED Sandbox",
+    "Owner": "Gess1t",
+    "Description": "allow users to use images of 64x128 resolution and show them on any of the 2 LED display contained within Wacom PTK-x40 tablets.",
+    "PluginVersion": "1.0.3",
+    "SupportedDriverVersion": "0.5.3.3",
+    "RepositoryUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.LEDSandbox/releases/download/1.0.3-0.5.x-re/OTD.LEDSandbox-x86-0.5.x.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "1716c259c22e4bb48d82584773660ffe4fafbf647ca98552af5803ece019f97c",
+    "WikiUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
+    "LicenseIdentifier": "MIT"
+}

--- a/Repository/0.6.4.0/Gess1t/OTD.LEDSanbox/OTD.LEDSanbox.json
+++ b/Repository/0.6.4.0/Gess1t/OTD.LEDSanbox/OTD.LEDSanbox.json
@@ -1,0 +1,13 @@
+{
+    "Name": "LED Sandbox",
+    "Owner": "Gess1t",
+    "Description": "Allow users to use images of 64x128 resolution and show them on any of the 2 LED display contained within Wacom PTK-x40 tablets.",
+    "PluginVersion": "1.0.3",
+    "SupportedDriverVersion": "0.6.4.0",
+    "RepositoryUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.LEDSandbox/releases/download/1.0.3-re/OTD.LEDSandbox-x86-0.6.x.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "d6d4e8dedf44f594a308643325e494501f65ca98b54ea79dcf85533141fb3d1f",
+    "WikiUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
+    "LicenseIdentifier": "MIT"
+}


### PR DESCRIPTION
Re-created the release, as for some reasons, the hash for one of the file in the first release was altered while i was working on another project? (Like i haven't touched that other repo in a month).
It should be fine now, unless it changes again after a while.