### PR TITLE
Add Wireless Kit Addon

### DIFF
--- a/Repository/0.5.3.3/Gess1t/WirelessKitAddon/WirelessKitAddon.json
+++ b/Repository/0.5.3.3/Gess1t/WirelessKitAddon/WirelessKitAddon.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Wireless Kit Addon",
+    "Owner": "Gess1t",
+    "Description": "Adds support for the Wireless Kit available for Wacom CTH tablets",
+    "PluginVersion": "1.0.0",
+    "SupportedDriverVersion": "0.5.3.3",
+    "RepositoryUrl": "https://github.com/Mrcubix/WirelessKitAddon",
+    "DownloadUrl": "https://github.com/Mrcubix/WirelessKitAddon/releases/download/1.0.0/WirelessKitAddon-0.5.x.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "027dd555b08b5b60c8ee2b50c7a3aec3e69575bb3c7bc6a98e617e0079ba29bf",
+    "WikiUrl": "https://github.com/Mrcubix/WirelessKitAddon/blob/master/README.md",
+    "LicenseIdentifier": "MIT"
+}

--- a/Repository/0.6.4.0/Gess1t/WirelessKitAddon/WirelessKitAddon.json
+++ b/Repository/0.6.4.0/Gess1t/WirelessKitAddon/WirelessKitAddon.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Wireless Kit Addon",
+    "Owner": "Gess1t",
+    "Description": "Adds support for the Wireless Kit available for Wacom CTH tablets",
+    "PluginVersion": "1.0.0",
+    "SupportedDriverVersion": "0.6.4.0",
+    "RepositoryUrl": "https://github.com/Mrcubix/WirelessKitAddon",
+    "DownloadUrl": "https://github.com/Mrcubix/WirelessKitAddon/releases/download/1.0.0/WirelessKitAddon-0.6.x.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "5c0b180aad4e5a4ad5b82e4fb4a90a41f832eb983840dc167693309f6256848b",
+    "WikiUrl": "https://github.com/Mrcubix/WirelessKitAddon/blob/master/README.md",
+    "LicenseIdentifier": "MIT"
+}


### PR DESCRIPTION
A plugin that reads the battery status provided by wireless kits & provide these readings to the user using a tray icon & notifications.

![Tray Icon](https://github.com/OpenTabletDriver/Plugin-Repository/assets/39861216/ef2a8d7d-5ce6-4d53-bef1-83d83231b436)
![Settings](https://github.com/OpenTabletDriver/Plugin-Repository/assets/39861216/e1968151-3ad2-4de6-b8f6-a9c2586f3086)
