### PR TITLE
Update Touch Gestures & Dependencies

### DIFF
--- a/Repository/0.5.3.3/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
+++ b/Repository/0.5.3.3/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
@@ -2,12 +2,12 @@
     "Name": "Enhanced Output Modes",
     "Owner": "Gess1t",
     "Description": "Enhanced Output Modes for OpenTabletDriver (Adds support for Touch Input, Plugin report access, ...)",
-    "PluginVersion": "1.1.1",
+    "PluginVersion": "1.1.3",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.1/OTD.EnhancedOutputMode-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.3/OTD.EnhancedOutputMode-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "0bc72c774154704d2ceeba643ce1288213e9c7ad6a400755367110533dfd3d1f",
+    "SHA256": "fdb050a95f060c359fc217deacac20173890ce1b31c451b2e784dadc23322792",
     "WikiUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.5.3.3/Gess1t/Touch-Gestures/Touch-Gestures.json
+++ b/Repository/0.5.3.3/Gess1t/Touch-Gestures/Touch-Gestures.json
@@ -2,12 +2,12 @@
     "Name": "Touch Gestures Installer",
     "Owner": "Gess1t",
     "Description": "Adds support for Touch Gestures to OpenTabletDriver",
-    "PluginVersion": "1.0.1",
+    "PluginVersion": "1.0.2",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/Touch-Gestures/",
-    "DownloadUrl": "https://github.com/Mrcubix/Touch-Gestures/releases/download/1.0.1/Touch-Gestures.Installer-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Touch-Gestures/releases/download/1.0.2/Touch-Gestures.Installer-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "0cb10916a9e6c8872211d1f80ce67a84b3c0573b192426271e9bc934242a3141",
+    "SHA256": "a8c77463014674c120f146998cee0718797071fc59ce1ad934a07c4cc70e0013",
     "WikiUrl": "https://mrcubix.github.io/Touch-Gestures-Doc/",
     "LicenseIdentifier": "MIT"
 }

--- a/Repository/0.6.4.0/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
+++ b/Repository/0.6.4.0/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
@@ -2,12 +2,12 @@
     "Name": "Enhanced Output Modes",
     "Owner": "Gess1t",
     "Description": "Enhanced Output Modes for OpenTabletDriver (Adds support for Touch Inputs)",
-    "PluginVersion": "1.1.2",
+    "PluginVersion": "1.1.3",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.2-0.6.x/OTD.EnhancedOutputMode-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.3-0.6.x/OTD.EnhancedOutputMode-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "a753285fe75333b292c5094d0203deabf0ae24b9fd6e065ac6535f4b329964e2",
+    "SHA256": "b5be49a20f70a0198adc05acc5c3de94c35d7d1d13c321a8dfe8ac87d36bbd57",
     "WikiUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.4.0/Gess1t/Touch-Gestures/Touch-Gestures.json
+++ b/Repository/0.6.4.0/Gess1t/Touch-Gestures/Touch-Gestures.json
@@ -2,12 +2,12 @@
     "Name": "Touch Gestures Installer",
     "Owner": "Gess1t",
     "Description": "Adds support for Touch Gestures to OpenTabletDriver",
-    "PluginVersion": "1.0.1",
+    "PluginVersion": "1.0.2",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/Touch-Gestures/",
-    "DownloadUrl": "https://github.com/Mrcubix/Touch-Gestures/releases/download/1.0.1/Touch-Gestures.Installer-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Touch-Gestures/releases/download/1.0.2/Touch-Gestures.Installer-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "a2969eef4a355d787676a056e3dcb3f8d7ac557c4205d5a71acc1dac1451ab64",
+    "SHA256": "e1878c90f19d05a7050a6ae1a4f46f10baf848aae77b0f0ac0b755ea2a2e1590",
     "WikiUrl": "https://mrcubix.github.io/Touch-Gestures-Doc/",
     "LicenseIdentifier": "MIT"
 }


### PR DESCRIPTION
## Changes (Touch Gestures)

- Worked around Avalonia bug preventing the Simple Binding Editor from working properly on Unix based platforms,
- Now preventing the user from starting a gesture setup when no tablets is plugged in,
- Fixes for the initialization on the 0.5.x version,
- Partially fix memory leak caused by OTD 0.6.x plugin handling,
- Fix No gesture screen not showing after deleting all gestures.

## Changes (OTD.EnhancedOutputMode)

- Added an option to skip touch inputs when a pen is in range