### PR TITLE
Update WirelessKitAddon to 1.0.4

### DIFF
--- a/Repository/0.5.3.3/Gess1t/WirelessKitAddon/WirelessKitAddon.json
+++ b/Repository/0.5.3.3/Gess1t/WirelessKitAddon/WirelessKitAddon.json
@@ -2,12 +2,12 @@
     "Name": "Wireless Kit Addon",
     "Owner": "Gess1t",
     "Description": "Adds support for the Wireless Kit available for Wacom CTH tablets",
-    "PluginVersion": "1.0.2",
+    "PluginVersion": "1.0.4",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/WirelessKitAddon",
-    "DownloadUrl": "https://github.com/Mrcubix/WirelessKitAddon/releases/download/1.0.2/WirelessKitAddon-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/WirelessKitAddon/releases/download/1.0.4/WirelessKitAddon-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "d65eb16f6ab780777a57359c8a8a3f34906348f0d62e99865306b2d962f58d00",
+    "SHA256": "12a62c4ddeed3f881beeeedcce2c2edd760675b06454c89d4d8454cbb99448ab",
     "WikiUrl": "https://github.com/Mrcubix/WirelessKitAddon/blob/master/README.md",
     "LicenseIdentifier": "MIT"
 }

--- a/Repository/0.6.4.0/Gess1t/WirelessKitAddon/WirelessKitAddon.json
+++ b/Repository/0.6.4.0/Gess1t/WirelessKitAddon/WirelessKitAddon.json
@@ -2,12 +2,12 @@
     "Name": "Wireless Kit Addon",
     "Owner": "Gess1t",
     "Description": "Adds support for the Wireless Kit available for Wacom CTH tablets",
-    "PluginVersion": "1.0.2",
+    "PluginVersion": "1.0.4",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/WirelessKitAddon",
-    "DownloadUrl": "https://github.com/Mrcubix/WirelessKitAddon/releases/download/1.0.2/WirelessKitAddon-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/WirelessKitAddon/releases/download/1.0.4/WirelessKitAddon-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "eb5dc80d5605b170dad15fb415afa0d6f77eac5fd16076f33e1313710980e03a",
+    "SHA256": "928ad9a978cfc6ce078f6bf2400a34284f0a5d090db3cb9e8ab89ed456a51074",
     "WikiUrl": "https://github.com/Mrcubix/WirelessKitAddon/blob/master/README.md",
     "LicenseIdentifier": "MIT"
 }


### PR DESCRIPTION
Added a settings to prevent notifications from being sent until the specified timespan after a connection has passed.
A negative value result in notifications being disabled.

This is necessary on certain platforms & case as the battery in wireless kits takes quite a while to be initialized.
Until It is initialized, the wireless kit will send 0% as the current charge, and there are currently no indicators of when it will be ready.