### PR TITLE
Update Preset.Binding to 1.1.0

### DIFF
--- a/Repository/0.6.0.3/Gess1t/Preset.Binding/Preset.Binding.json
+++ b/Repository/0.6.0.3/Gess1t/Preset.Binding/Preset.Binding.json
@@ -2,12 +2,12 @@
     "Name": "Preset Bindings",
     "Owner": "Gess1t",
     "Description": "A plugin for OTD 0.6.x to bind preset to tablet keys",
-    "PluginVersion": "1.0.0",
+    "PluginVersion": "1.1.0",
     "SupportedDriverVersion": "0.6.0.3",
     "RepositoryUrl": "https://github.com/Mrcubix/Preset.Binding",
-    "DownloadUrl": "https://github.com/Mrcubix/Preset.Binding/releases/download/1.0.0/Preset.Binding.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Preset.Binding/releases/download/1.1.0/Preset.Binding.zip",
     "CompressionFormat": "zip",
-    "SHA256": "3e175cb6574cfd0f7d4b55f6a9b22114065042350f63b0bd48aa0c5048bdb1e0",
+    "SHA256": "849e0d73636ce0a249ff21c7097a8619911857b9e7c09c177bec873ffa86af2f",
     "WikiUrl": "https://github.com/Mrcubix/Preset.Binding",
     "LicenseIdentifier": "MIT"
 }


### PR DESCRIPTION
Added optional support for OTD.UX.Remote (#102), for synchronizing the UX & sending notifications when switching profiles.