### PR TITLE
Updated Enhanced Output Mode to 1.1.5

### DIFF
--- a/Repository/0.5.3.3/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
+++ b/Repository/0.5.3.3/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
@@ -2,12 +2,12 @@
     "Name": "Enhanced Output Modes",
     "Owner": "Gess1t",
     "Description": "Enhanced Output Modes for OpenTabletDriver (Adds support for Touch Input, Plugin report access, ...)",
-    "PluginVersion": "1.1.3",
+    "PluginVersion": "1.1.5",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.3/OTD.EnhancedOutputMode-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.5/OTD.EnhancedOutputMode-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "fdb050a95f060c359fc217deacac20173890ce1b31c451b2e784dadc23322792",
+    "SHA256": "efeae01f455eaebf42daa273235dbc61923c66c1b61dd48f13e0fcd007f8b01c",
     "WikiUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.4.0/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
+++ b/Repository/0.6.4.0/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
@@ -2,12 +2,12 @@
     "Name": "Enhanced Output Modes",
     "Owner": "Gess1t",
     "Description": "Enhanced Output Modes for OpenTabletDriver (Adds support for Touch Inputs)",
-    "PluginVersion": "1.1.3",
+    "PluginVersion": "1.1.5",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.3-0.6.x/OTD.EnhancedOutputMode-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.5-0.6.x/OTD.EnhancedOutputMode-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "b5be49a20f70a0198adc05acc5c3de94c35d7d1d13c321a8dfe8ac87d36bbd57",
+    "SHA256": "8dc641ff1fb4f9805f3bbe54407727a1ead2ad9d0e4345561e7a496bbf6ad778",
     "WikiUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
Work around an issue in the 0.6.x version where some interpolators would prevent touch inputs from going through the pipeline.
(can't do anything about other types of inputs being blocked though)