### PR TITLE
Add Scroll bindings

### DIFF
--- a/Repository/0.5.3.3/Gess1t/ScrollBindings/ScrollBindings.json
+++ b/Repository/0.5.3.3/Gess1t/ScrollBindings/ScrollBindings.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Scroll Bindings",
+    "Owner": "Gess1t",
+    "Description": "Adds support for scrolling using aux keys or others on Windows & Linux.",
+    "PluginVersion": "1.0.0",
+    "SupportedDriverVersion": "0.5.3.3",
+    "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
+    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.0/ScrollBindings-0.5.x.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "b0bc733ae5ca81e739de4618001e940f27391007ea0226f5118b9d63ee04abd4",
+    "WikiUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
+    "LicenseIdentifier": "MIT"
+}

--- a/Repository/0.5.3.3/Gess1t/ScrollBindings/ScrollBindings.json
+++ b/Repository/0.5.3.3/Gess1t/ScrollBindings/ScrollBindings.json
@@ -2,12 +2,12 @@
     "Name": "Scroll Bindings",
     "Owner": "Gess1t",
     "Description": "Adds support for scrolling using aux keys or others on Windows & Linux.",
-    "PluginVersion": "1.0.0",
+    "PluginVersion": "1.0.1",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
-    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.0/ScrollBindings-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.1/ScrollBindings-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "b0bc733ae5ca81e739de4618001e940f27391007ea0226f5118b9d63ee04abd4",
+    "SHA256": "37438b1cc4490665b95e2ee708b0505dfd7aee71fdd7a35bd315a4deef5e2bcc",
     "WikiUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
     "LicenseIdentifier": "MIT"
 }

--- a/Repository/0.6.4.0/Gess1t/ScrollBindings/ScrollBindings.json
+++ b/Repository/0.6.4.0/Gess1t/ScrollBindings/ScrollBindings.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Scroll Bindings",
+    "Owner": "Gess1t",
+    "Description": "Adds support for scrolling using aux keys or others on Windows & Linux.",
+    "PluginVersion": "1.0.0",
+    "SupportedDriverVersion": "0.6.4.0",
+    "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
+    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.0/ScrollBindings-0.6.x.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "4062d3315544d66d82657b155602d7a47cfb100bd298ac0db487163b7c9f0018",
+    "WikiUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
+    "LicenseIdentifier": "MIT"
+}

--- a/Repository/0.6.4.0/Gess1t/ScrollBindings/ScrollBindings.json
+++ b/Repository/0.6.4.0/Gess1t/ScrollBindings/ScrollBindings.json
@@ -2,12 +2,12 @@
     "Name": "Scroll Bindings",
     "Owner": "Gess1t",
     "Description": "Adds support for scrolling using aux keys or others on Windows & Linux.",
-    "PluginVersion": "1.0.0",
+    "PluginVersion": "1.0.1",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
-    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.0/ScrollBindings-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.1/ScrollBindings-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "4062d3315544d66d82657b155602d7a47cfb100bd298ac0db487163b7c9f0018",
+    "SHA256": "ca46d8e4fac3a9707ae131ba5c09d96bdebe74e971b4b328e7aea91732474990",
     "WikiUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
     "LicenseIdentifier": "MIT"
 }


### PR DESCRIPTION
This is a plugin that adds support for scrolling vertically & horizontally on Windows & Linux.

MacOS isn't supported, as i cannot test it, and i can't figure it out anyway.
It's not worth going through the Apple Brainwash.

Available for both 0.5.x & 0.6.x, as per usual.

### Changelog for 1.0.1

- Fix Settings, they will now match 0.5.x & are the same for every tablets,
- Fix scrolling not stopping after being started (i pressed scroll forward then backward & a war began).