### PR TITLE
Bump bettercalibrator to 0.1.3

### DIFF
--- a/Repository/0.6.3.0/TheBlueOompaLoompa/BetterCalibrator/BetterCalibrator.json
+++ b/Repository/0.6.3.0/TheBlueOompaLoompa/BetterCalibrator/BetterCalibrator.json
@@ -2,12 +2,12 @@
   "Name": "BetterCalibrator",
   "Owner": "TheBlueOompaLoompa",
   "Description": "Calibrate your tablet faster and easier",
-  "PluginVersion": "0.1.2",
+  "PluginVersion": "0.1.3",
   "SupportedDriverVersion": "0.6.3.0",
   "RepositoryUrl": "https://github.com/TheBlueOompaLoompa/BetterCalibrator",
-  "DownloadUrl": "https://github.com/TheBlueOompaLoompa/BetterCalibrator/releases/download/0.1.2/BetterCalibrator.zip",
+  "DownloadUrl": "https://github.com/TheBlueOompaLoompa/BetterCalibrator/releases/download/0.1.3/BetterCalibrator.zip",
   "CompressionFormat": "zip",
-  "SHA256": "76f538cc197a1fef26e065991669c63017c51dc467a0124def7923463937cedb",
+  "SHA256": "57ff0d0ae3238b1887101b1b2ef55fc3b6685a99f9191511fb6375ef1ead37b1",
   "WikiUrl": "https://github.com/TheBlueOompaLoompa/BetterCalibrator/blob/master/README.md",
   "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
Fixes the plugin causing crashing or tablet undetection when enabled in OTD without setting up calibration with the gui tool beforehand.

The plugin's creator has given permission for me to create a new release of this plugin on his behalf. https://github.com/TheBlueOompaLoompa/BetterCalibrator/issues/6#issuecomment-2356741722
