### PR TITLE
Update Scroll Binding to 1.0.2

### DIFF
--- a/Repository/0.5.3.3/Gess1t/ScrollBindings/ScrollBindings.json
+++ b/Repository/0.5.3.3/Gess1t/ScrollBindings/ScrollBindings.json
@@ -2,12 +2,12 @@
     "Name": "Scroll Bindings",
     "Owner": "Gess1t",
     "Description": "Adds support for scrolling using aux keys or others on Windows & Linux.",
-    "PluginVersion": "1.0.1",
+    "PluginVersion": "1.0.2",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
-    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.1/ScrollBindings-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.2/ScrollBindings-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "37438b1cc4490665b95e2ee708b0505dfd7aee71fdd7a35bd315a4deef5e2bcc",
+    "SHA256": "c27f15c7083badacb3743fbbf646d90b06bbaf72b1ac1b33a7eb5e1626d9e0e3",
     "WikiUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
     "LicenseIdentifier": "MIT"
 }

--- a/Repository/0.6.4.0/Gess1t/ScrollBindings/ScrollBindings.json
+++ b/Repository/0.6.4.0/Gess1t/ScrollBindings/ScrollBindings.json
@@ -2,12 +2,12 @@
     "Name": "Scroll Bindings",
     "Owner": "Gess1t",
     "Description": "Adds support for scrolling using aux keys or others on Windows & Linux.",
-    "PluginVersion": "1.0.1",
+    "PluginVersion": "1.0.2",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
-    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.1/ScrollBindings-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.2/ScrollBindings-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "ca46d8e4fac3a9707ae131ba5c09d96bdebe74e971b4b328e7aea91732474990",
+    "SHA256": "713e748b055940a75afdbb718f3299259c38cf13a4427e8e8aeee471fad76021",
     "WikiUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
     "LicenseIdentifier": "MIT"
 }


### PR DESCRIPTION
Add the ability for users to set settings per bindings in 0.6.x.

A new Legacy Scroll Binding option has been created to ensure old bindings still work as intended.
I might go through the process of deprecating then removing them down the line.

![New Binding](https://i.imgur.com/bHctcdI.png)