### PR TITLE
Update ScrollBindings to 1.0.3

### DIFF
--- a/Repository/0.5.3.3/Gess1t/ScrollBindings/ScrollBindings.json
+++ b/Repository/0.5.3.3/Gess1t/ScrollBindings/ScrollBindings.json
@@ -2,12 +2,12 @@
     "Name": "Scroll Bindings",
     "Owner": "Gess1t",
     "Description": "Adds support for scrolling using aux keys or others on Windows & Linux.",
-    "PluginVersion": "1.0.2",
+    "PluginVersion": "1.0.3",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
-    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.2/ScrollBindings-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.3/ScrollBindings-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "c27f15c7083badacb3743fbbf646d90b06bbaf72b1ac1b33a7eb5e1626d9e0e3",
+    "SHA256": "1eb251cb3f026d6056a192621eea4b735e3855a5db212927fecad620edfe569c",
     "WikiUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
     "LicenseIdentifier": "MIT"
 }

--- a/Repository/0.6.4.0/Gess1t/ScrollBindings/ScrollBindings.json
+++ b/Repository/0.6.4.0/Gess1t/ScrollBindings/ScrollBindings.json
@@ -2,12 +2,12 @@
     "Name": "Scroll Bindings",
     "Owner": "Gess1t",
     "Description": "Adds support for scrolling using aux keys or others on Windows & Linux.",
-    "PluginVersion": "1.0.2",
+    "PluginVersion": "1.0.3",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
-    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.2/ScrollBindings-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.3/ScrollBindings-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "713e748b055940a75afdbb718f3299259c38cf13a4427e8e8aeee471fad76021",
+    "SHA256": "db13befd8eb392c7c302c15f1b77c7c66b985c7089b11a9c4174dfb2fab598a5",
     "WikiUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
     "LicenseIdentifier": "MIT"
 }


### PR DESCRIPTION
## Changes

- Fix Legacy & 0.5.x settings not being used when changed are made after first init,
- Now using native timers (& Fallback timer when necessary) instead of .NET's Stopwatch,
- Lowered the minimum delay to 1 ms thanks to the previous changes.