### PR TITLE
Update TemporalResampler to v1.4.1

### DIFF
--- a/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
+++ b/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
@@ -2,12 +2,12 @@
     "Name": "Temporal Resampler",
     "Owner": "shmkle",
     "Description": "Input resampler for higher hz monitors.",
-    "PluginVersion": "1.2.4",
+    "PluginVersion": "1.4.0",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/shmkle/TemporalResampler",
-    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.2.4/TemporalResampler.zip",
+    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.4.0/TemporalResampler.zip",
     "CompressionFormat": "zip",
-    "SHA256": "28d9aa48dc2102c9c7c313b2e60202d406a8b0550b053894dba8711997a441b5",
+    "SHA256": "b2e8bba460ab2c7c27d6ac7af9ebd4d8c21eea7d901ffe28a74369740c8db1aa",
     "WikiUrl": "https://github.com/shmkle/TemporalResampler/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
+++ b/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
@@ -2,12 +2,12 @@
     "Name": "Temporal Resampler",
     "Owner": "shmkle",
     "Description": "Input resampler for higher hz monitors.",
-    "PluginVersion": "1.4.0",
+    "PluginVersion": "1.4.1",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/shmkle/TemporalResampler",
-    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.4.0/TemporalResampler.zip",
+    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.4.1/TemporalResampler.zip",
     "CompressionFormat": "zip",
-    "SHA256": "b2e8bba460ab2c7c27d6ac7af9ebd4d8c21eea7d901ffe28a74369740c8db1aa",
+    "SHA256": "a183c4f704d15d9411e41e0c63de0e1e93034c50c0e50c4d5aecb733de6e4f3f",
     "WikiUrl": "https://github.com/shmkle/TemporalResampler/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
- prediction now uses Kalman filtering approach.
- fixed blocking unhandled input types, including intous3 mouse.
- change the clock code to a new "temporal acceleration"-based approach.
- changes to trajectory calculations.