### PR TITLE
Add Relative Mode Area Plugin

### DIFF
--- a/Repository/0.6.4.0/Gess1t/RelativeModeArea/RelativeModeArea.json
+++ b/Repository/0.6.4.0/Gess1t/RelativeModeArea/RelativeModeArea.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Relative Mode Area",
+    "Owner": "Gess1t",
+    "Description": "A plugin to limit the user area.",
+    "PluginVersion": "1.0.3",
+    "SupportedDriverVersion": "0.6.4.0",
+    "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
+    "DownloadUrl": "https://github.com/Mrcubix/RelativeModeArea/releases/download/1.0.3/RelativeModeArea.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "baf23d882bb2d6e788ee3ab77bbc7fe080dcf1262702eca27ca697218c68c9f1",
+    "WikiUrl": "https://github.com/Mrcubix/RelativeModeArea/blob/master/README.md#how-to-use",
+    "LicenseIdentifier": "MIT"
+}


### PR DESCRIPTION
This is a plugin that allow users that wished it to limit the area within which a user may move their pen or mouse to move the cursor.

Another version supporting touch inputs is also available on the repo, but not provided here as it requires manual setup.