### PR TITLE
Update OTD.EnhancedOutputMode to 1.1.9

### DIFF
--- a/Repository/0.5.3.3/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
+++ b/Repository/0.5.3.3/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
@@ -2,12 +2,12 @@
     "Name": "Enhanced Output Modes",
     "Owner": "Gess1t",
     "Description": "Enhanced Output Modes for OpenTabletDriver (Adds support for Touch Input, Plugin report access, ...)",
-    "PluginVersion": "1.1.6",
+    "PluginVersion": "1.1.9",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.6/OTD.EnhancedOutputMode-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.9/OTD.EnhancedOutputMode-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "bee2ad974806f79f52a49f8c6dda4665f7a060b5377b1a3a54eb05bff200124b",
+    "SHA256": "b765e9203dde7923111d5dcd9e879e1a9a06b6287d43d0623727354bb7edaa78",
     "WikiUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.4.0/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
+++ b/Repository/0.6.4.0/Gess1t/OTD.EnhancedOutputMode/OTD.EnhancedOutputMode.json
@@ -2,12 +2,12 @@
     "Name": "Enhanced Output Modes",
     "Owner": "Gess1t",
     "Description": "Enhanced Output Modes for OpenTabletDriver (Adds support for Touch Inputs)",
-    "PluginVersion": "1.1.6",
+    "PluginVersion": "1.1.9",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.6-0.6.x/OTD.EnhancedOutputMode-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode/releases/download/1.1.9-0.6.x/OTD.EnhancedOutputMode-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "091ba3dbadde10a7426ddeff5418715fd318580ee625c93d08913b6ffd95209e",
+    "SHA256": "9f82195a0d0d08e42c7a9fe268a7dd2478f01891cabf63499a06669e7c244d77",
     "WikiUrl": "https://github.com/Mrcubix/OTD.EnhancedOutputMode",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
- Fix display name of Bindings for Vmulti & Windows Ink output modes.
- Add an option for the motion of touch input to match pen inputs.

New settings will be available in Touch Settings under Match Pen Sensibility in Relative Mode.
New behavior may be ignoring Reset Time.