### PR TITLE
Update OTD.LEDSandbox to 1.0.4

### DIFF
--- a/Repository/0.5.3.3/Gess1t/OTD.LEDSandbox/OTD.LEDSandbox.json
+++ b/Repository/0.5.3.3/Gess1t/OTD.LEDSandbox/OTD.LEDSandbox.json
@@ -2,12 +2,12 @@
     "Name": "LED Sandbox",
     "Owner": "Gess1t",
     "Description": "allow users to use images of 64x128 resolution and show them on any of the 2 LED display contained within Wacom PTK-x40 tablets.",
-    "PluginVersion": "1.0.3",
+    "PluginVersion": "1.0.4",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.LEDSandbox/releases/download/1.0.3-0.5.x-re/OTD.LEDSandbox-x86-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.LEDSandbox/releases/download/1.0.4-0.5.x/OTD.LEDSandbox-x86-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "1716c259c22e4bb48d82584773660ffe4fafbf647ca98552af5803ece019f97c",
+    "SHA256": "b7a7a63ac5c049369f9ef037e0184c52371d7e8e47f8de6d2ea597d6df371aa0",
     "WikiUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
     "LicenseIdentifier": "MIT"
 }

--- a/Repository/0.6.4.0/Gess1t/OTD.LEDSanbox/OTD.LEDSanbox.json
+++ b/Repository/0.6.4.0/Gess1t/OTD.LEDSanbox/OTD.LEDSanbox.json
@@ -2,12 +2,12 @@
     "Name": "LED Sandbox",
     "Owner": "Gess1t",
     "Description": "Allow users to use images of 64x128 resolution and show them on any of the 2 LED display contained within Wacom PTK-x40 tablets.",
-    "PluginVersion": "1.0.3",
+    "PluginVersion": "1.0.4",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
-    "DownloadUrl": "https://github.com/Mrcubix/OTD.LEDSandbox/releases/download/1.0.3-re/OTD.LEDSandbox-x86-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/OTD.LEDSandbox/releases/download/1.0.4/OTD.LEDSandbox-x86-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "d6d4e8dedf44f594a308643325e494501f65ca98b54ea79dcf85533141fb3d1f",
+    "SHA256": "48e3fd8f6626df112e2ab6a26cea66a9ff877bd4207e50226ecb4178409f6ce0",
     "WikiUrl": "https://github.com/Mrcubix/OTD.LEDSandbox",
     "LicenseIdentifier": "MIT"
 }


### PR DESCRIPTION
Worked around a .NET bug, where it doesn't check the `runtimes` folder on linux.
Copying native libs to the root of the plugin instead.

https://github.com/Mrcubix/OTD.LEDSandbox/commit/3affb1ad38979815c10fca978765f628af5a4733