### PR TITLE
Update Scroll Bindings to 1.0.4

### DIFF
--- a/Repository/0.5.3.3/Gess1t/ScrollBindings/ScrollBindings.json
+++ b/Repository/0.5.3.3/Gess1t/ScrollBindings/ScrollBindings.json
@@ -1,13 +1,13 @@
 {
     "Name": "Scroll Bindings",
     "Owner": "Gess1t",
-    "Description": "Adds support for scrolling using aux keys or others on Windows & Linux.",
-    "PluginVersion": "1.0.3",
+    "Description": "Adds support for scrolling using aux keys or others on Windows, Linux & MacOS.",
+    "PluginVersion": "1.0.4",
     "SupportedDriverVersion": "0.5.3.3",
     "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
-    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.3/ScrollBindings-0.5.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.4/ScrollBindings-0.5.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "1eb251cb3f026d6056a192621eea4b735e3855a5db212927fecad620edfe569c",
+    "SHA256": "b38543047d11df236683aa0c4ee0f2f3d50c04efd41b5452b05da25941dfc303",
     "WikiUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
     "LicenseIdentifier": "MIT"
 }

--- a/Repository/0.6.4.0/Gess1t/ScrollBindings/ScrollBindings.json
+++ b/Repository/0.6.4.0/Gess1t/ScrollBindings/ScrollBindings.json
@@ -1,13 +1,13 @@
 {
     "Name": "Scroll Bindings",
     "Owner": "Gess1t",
-    "Description": "Adds support for scrolling using aux keys or others on Windows & Linux.",
-    "PluginVersion": "1.0.3",
+    "Description": "Adds support for scrolling using aux keys or others on Windows, Linux & MacOS.",
+    "PluginVersion": "1.0.4",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
-    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.3/ScrollBindings-0.6.x.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Scroll-Bindings/releases/download/1.0.4/ScrollBindings-0.6.x.zip",
     "CompressionFormat": "zip",
-    "SHA256": "db13befd8eb392c7c302c15f1b77c7c66b985c7089b11a9c4174dfb2fab598a5",
+    "SHA256": "9d7c5e44f9d6b922dfb63d8316ecd8c3729bab957da830c67585908f3f0fe721",
     "WikiUrl": "https://github.com/Mrcubix/Scroll-Bindings/",
     "LicenseIdentifier": "MIT"
 }


### PR DESCRIPTION
## Changes

- Added Support For MacOS (Thanks to @AkiSakurai for working rather fast on this)

Feedback from MacOS users is appreciated as without it, we cannot properly integrate the feature in OpenTabletDriver.

## Hashes

b38543047d11df236683aa0c4ee0f2f3d50c04efd41b5452b05da25941dfc303  ScrollBindings-0.5.x.zip
9d7c5e44f9d6b922dfb63d8316ecd8c3729bab957da830c67585908f3f0fe721  ScrollBindings-0.6.x.zip