### PR TITLE
Validate JSON directory paths

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -25,6 +25,7 @@ test_dependencies() {
   test_dep "sha256sum"
   test_dep "jq"
   test_dep "xargs"
+  test_dep "find"
 }
 
 check_sha256() {

--- a/validate.sh
+++ b/validate.sh
@@ -28,6 +28,23 @@ test_dependencies() {
   test_dep "find"
 }
 
+test_repository_structure() {
+  cd "${ROOTDIR}"
+  if [ ! -d "Repository" ]; then
+    print_clr ${ERROR} " Repository is missing expected 'Repository' folder"
+    exit 104
+  fi
+  while read LINE; do
+    if ! [[ "$LINE" =~ ^Repository/[0-9]([.][0-9]){3}(/[^/]+){2}/[^/]+json$ ]]; then
+      error=$?
+      print_clr ${ERROR} "  FAIL: Invalid path ${LINE}"
+    fi
+  done < <(find Repository/ -iname '*.json' -type f)
+
+  [ ! -z "$error" ] && exit $error
+  print_clr ${SUCCESS}  "  SUCCESS: Repository directory structure"
+}
+
 check_sha256() {
   [ "$#" -ne 2 ] && exit 103;
 
@@ -54,6 +71,7 @@ validate() {
 }
 
 test_dependencies
+test_repository_structure
 
 for file in ${ROOTDIR}/**; do
   [ "${file: -5}" == ".json" ] && validate "${file}"


### PR DESCRIPTION
This adds tests for JSON directory paths to avoid future fixup PR's like #90 and #126

Example output when a file isn't in its correct location:
> $ ./validate.sh 
  FAIL: Invalid path Repository/0.6.4.0/Vineyo/TiltCalibration.json