### PR TITLE
Update TemporalResampler to v1.5.0

### DIFF
--- a/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
+++ b/Repository/0.6.4.0/shmkle/TemporalResampler/TemporalResampler.json
@@ -2,12 +2,12 @@
     "Name": "Temporal Resampler",
     "Owner": "shmkle",
     "Description": "Input resampler for higher hz monitors.",
-    "PluginVersion": "1.4.1",
+    "PluginVersion": "1.5.0",
     "SupportedDriverVersion": "0.6.4.0",
     "RepositoryUrl": "https://github.com/shmkle/TemporalResampler",
-    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.4.1/TemporalResampler.zip",
+    "DownloadUrl": "https://github.com/shmkle/TemporalResampler/releases/download/v1.5.0/TemporalResampler.zip",
     "CompressionFormat": "zip",
-    "SHA256": "a183c4f704d15d9411e41e0c63de0e1e93034c50c0e50c4d5aecb733de6e4f3f",
+    "SHA256": "548c4dc865794415b3f355c704c7186f0683d865d95cf6cd52ef1b923e271563",
     "WikiUrl": "https://github.com/shmkle/TemporalResampler/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
- change the time code to handle more unstable tablets
- fixed cursor jittering when alt-tabbing
- removed the two dependacies
- minor tweaks to the kalman prediction code
- added interpolation to pressure
- pressure now gets smoothed if smoothing is added