### PR TITLE
Update Preset Binding to 1.2.0

### DIFF
--- a/Repository/0.6.0.3/Gess1t/Preset.Binding/Preset.Binding.json
+++ b/Repository/0.6.0.3/Gess1t/Preset.Binding/Preset.Binding.json
@@ -2,12 +2,12 @@
     "Name": "Preset Bindings",
     "Owner": "Gess1t",
     "Description": "A plugin for OTD 0.6.x to bind preset to tablet keys",
-    "PluginVersion": "1.1.1",
+    "PluginVersion": "1.2.0",
     "SupportedDriverVersion": "0.6.0.3",
     "RepositoryUrl": "https://github.com/Mrcubix/Preset.Binding",
-    "DownloadUrl": "https://github.com/Mrcubix/Preset.Binding/releases/download/1.1.1/Preset.Binding.zip",
+    "DownloadUrl": "https://github.com/Mrcubix/Preset.Binding/releases/download/1.2.0/Preset.Binding.zip",
     "CompressionFormat": "zip",
-    "SHA256": "56eb62b0366ba316b3338c752293cdf1aa179cfdce27d902911d557e29d52c90",
+    "SHA256": "e4fb4f014298fc64578b1c307279f33fb57fc88508ca57c5cf7e74f42ad4fb30",
     "WikiUrl": "https://github.com/Mrcubix/Preset.Binding",
     "LicenseIdentifier": "MIT"
 }

--- a/Repository/0.6.0.3/Gess1t/Preset.Binding/Preset.Binding.json
+++ b/Repository/0.6.0.3/Gess1t/Preset.Binding/Preset.Binding.json
@@ -4,6 +4,7 @@
     "Description": "A plugin for OTD 0.6.x to bind preset to tablet keys",
     "PluginVersion": "1.2.0",
     "SupportedDriverVersion": "0.6.0.3",
+    "MaxSupportedDriverVersion": "0.6.5.1",
     "RepositoryUrl": "https://github.com/Mrcubix/Preset.Binding",
     "DownloadUrl": "https://github.com/Mrcubix/Preset.Binding/releases/download/1.2.0/Preset.Binding.zip",
     "CompressionFormat": "zip",


### PR DESCRIPTION
## Changelog

- Stability should be improved significantly, the plugin should not fail as often as it did on some systems before.

## Note

For UX synchronization & Notification, install [OTD.UX.Remote](https://github.com/Mrcubix/OTD.UX.Remote/releases/latest) via the Plugin Manager or the linked repo.

## Hashes

e4fb4f014298fc64578b1c307279f33fb57fc88508ca57c5cf7e74f42ad4fb30  Preset.Binding.zip

## Notice

~~The plugin is to be removed once https://github.com/OpenTabletDriver/OpenTabletDriver/pull/3995 is merged & a new release is out with the integration~~

The PR has been merged & is now integrated into OTD, as such, the plugin will be EOL for any future OTD version past 0.6.5.1.