### PR TITLE
Update Circular Area to 3.2.1

### DIFF
--- a/Repository/0.6.1.0/Kuuuube/Circular_Area/Circular_Area.json
+++ b/Repository/0.6.1.0/Kuuuube/Circular_Area/Circular_Area.json
@@ -2,12 +2,12 @@
     "Name": "Circular Area",
     "Owner": "Kuuuube",
     "Description": "Circular mapping for tablet areas.",
-    "PluginVersion": "3.2.0.0",
+    "PluginVersion": "3.2.1.0",
     "SupportedDriverVersion": "0.6.1.0",
     "RepositoryUrl": "https://github.com/Kuuuube/Circular_Area",
-    "DownloadUrl": "https://github.com/Kuuuube/Circular_Area/releases/download/3.2.0/3.2.0_release_Circular_Area.zip",
+    "DownloadUrl": "https://github.com/Kuuuube/Circular_Area/releases/download/3.2.1/3.2.1_release_Circular_Area.zip",
     "CompressionFormat": "zip",
-    "SHA256": "478ed309f0410da0729ee4e23a1835db1ea035b28460d2894895949e79709ab5",
+    "SHA256": "4f4bf2949aac244625676ed1f74be3effba6dc6b3c99d79cb371dcbe2b144cdb",
     "WikiUrl": "https://github.com/Kuuuube/Circular_Area/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
Should fix circular area being unable to load on non x64 architectures.