### PR TITLE
Add Frenet-Serret Frame Predictor plugin

### DIFF
--- a/Repository/0.6.7.0/make-42/otd-frenet-serret-frame-predictor/otd-frenet-serret-frame-predictor.json
+++ b/Repository/0.6.7.0/make-42/otd-frenet-serret-frame-predictor/otd-frenet-serret-frame-predictor.json
@@ -1,0 +1,13 @@
+{
+    "Name": "OnTake's Frenet-Serret Frame Predictor",
+    "Owner": "make-42",
+    "Description": "Predicts future pen position using Frenet-Serret frame mathematics, reducing perceived input latency by extrapolating cursor movement along the natural curve of the stroke.",
+    "PluginVersion": "1.1.0",
+    "SupportedDriverVersion": "0.6.7.0",
+    "RepositoryUrl": "https://github.com/make-42/otd-frenet-serret-frame-predictor",
+    "DownloadUrl": "https://github.com/make-42/otd-frenet-serret-frame-predictor/releases/download/v1.1/FrenetSerretFramePredictor.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "47e06b638616e7705e35acd8f0bd0a1e81cdc4e47868841bd8f310826dffba5c",
+    "WikiUrl": "https://github.com/make-42/otd-frenet-serret-frame-predictor",
+    "LicenseIdentifier": "MIT"
+}


### PR DESCRIPTION
I wrote this little plugin to trade a bit of added jitter/jaggedness for predicting a few reports into the future for tablets with a bit of latency.

 - First it'll get the last few reports from your tablet
 - Then it'll fit a cubic B-spline through them to smooth them out
 - Finally it'll compute tangential and normal acceleration over that timespan in a Frenet-Serret reference frame linked to the cursor and its past trajectory (pretty much just determining direction of movement and signed curvature).
 - Then it'll compute a average of the derivatives of those accelerations over that period giving more weight to the recent samples.
 - Then it'll just integrate with those derivative values to compute a prediction of where the Frenet-Serret frame should be at a set offset in the future.
 
 Perceived latency goes down...