### PR TITLE
Update The Saturn Collection to 0.9.1

### DIFF
--- a/Repository/0.6.6.2/shreddism/TheSaturnCollection/TheSaturnCollection.json
+++ b/Repository/0.6.6.2/shreddism/TheSaturnCollection/TheSaturnCollection.json
@@ -2,12 +2,12 @@
     "Name": "The Saturn Collection",
     "Owner": "shreddism",
     "Description": "The Enhanced Plugin Experience.\n - Configurable antichatter with virtually 0 extra latency and aspect ratio compensation\n - Multiple available optional minimal-latency interpolation methods\n - Behavioral tweaks to reduce interpolation press/lift bugging on Wacom PTK-x70 tablets\n - Output mode with realtime area changing and bindable actions\n ...and more!",
-    "PluginVersion": "0.9.0",
+    "PluginVersion": "0.9.1",
     "SupportedDriverVersion": "0.6.6.2",
     "RepositoryUrl": "https://github.com/shreddism/TheSaturnCollection",
-    "DownloadUrl": "https://github.com/shreddism/TheSaturnCollection/releases/download/0.9.0/Saturn.zip",
+    "DownloadUrl": "https://github.com/shreddism/TheSaturnCollection/releases/download/0.9.1/Saturn.zip",
     "CompressionFormat": "zip",
-    "SHA256": "a7a701c57d76d5ca8a43b011b604a590a3266f56f41d58746353a5f5e28ddbad",
+    "SHA256": "2d3ef8195829b1d1a0b16ae222c263e2ea9a924c82d46d02835b31416209e266",
     "WikiUrl": "https://github.com/shreddism/TheSaturnCollection/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
[Release link](https://github.com/shreddism/TheSaturnCollection/releases/tag/0.9.1)
- Fixed edgecase handling for PTK-x70 press/release in both options of interpolation, massively reducing visual bugging (especially if using some prediction). Makes a smooth cursortrail a lot more usable.