### PR TITLE
Update The Saturn Collection to 0.10.0

### DIFF
--- a/Repository/0.6.7.0/shreddism/TheSaturnCollection/TheSaturnCollection.json
+++ b/Repository/0.6.7.0/shreddism/TheSaturnCollection/TheSaturnCollection.json
@@ -1,0 +1,13 @@
+{
+    "Name": "The Saturn Collection",
+    "Owner": "shreddism",
+    "Description": "The Enhanced Plugin Experience.\n - Configurable antichatter with virtually 0 extra latency\n - Optional interpolation that doesn't mess with filtering\n - Greatly improved prediction and reduced bugs on certain tablets\n - Output mode with realtime area changing and bindable actions\n ...and more!",
+    "PluginVersion": "0.10.0",
+    "SupportedDriverVersion": "0.6.7",
+    "RepositoryUrl": "https://github.com/shreddism/TheSaturnCollection",
+    "DownloadUrl": "https://github.com/shreddism/TheSaturnCollection/releases/download/0.10.0/Saturn.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "79d03c73529a49d766983342fbbb3e5bdb997f339432401ff0d8ee484040fadf",
+    "WikiUrl": "https://github.com/shreddism/TheSaturnCollection/blob/main/README.md",
+    "LicenseIdentifier": "GPL-3.0-only"
+}


### PR DESCRIPTION
notes from [release](https://github.com/shreddism/TheSaturnCollection/releases/tag/0.10.0):
- Add Area Rounding (Circular Area-like effect, operates on cursor distance from center, configurable for "normal" or "inverse")
- Fix prediction basically not doing anything
- Only give Directional Antichatter an outer radius (threshold), basically preserve function for more setting space
- Rework Accel Response Aggressiveness to be far better with different areas/create a wider range of potential usable values
- Reorder settings to be more intuitive
- Change the Kalman Filter to use acceleration along with position/velocity
- Combine multifilters into one to prevent confusion
- Make interpolation an option
- Add auto-detect tablet for tweaks
- Attempted prediction improvement for most Wacom tablets (PTK-470, CTL-480 tested)
- Attempted press/lift bugfixing for some Wacom tablets