### PR TITLE
Add `Windows Pen Pointer` and update `VMultiMode` and `Windows Ink`

### DIFF
--- a/Repository/0.6.6.0/Kuuuube/VoiDPlugins/VMultiMode.json
+++ b/Repository/0.6.6.0/Kuuuube/VoiDPlugins/VMultiMode.json
@@ -2,12 +2,12 @@
     "Name": "VMultiMode",
     "Owner": "Kuuuube",
     "Description": "Classic VMulti Output Mode",
-    "PluginVersion": "0.5.1",
+    "PluginVersion": "0.5.2",
     "SupportedDriverVersion": "0.6.6.0",
     "RepositoryUrl": "https://github.com/Kuuuube/VoiDPlugins",
-    "DownloadUrl": "https://github.com/Kuuuube/VoiDPlugins/releases/download/0.5.1/VMultiMode.zip",
+    "DownloadUrl": "https://github.com/Kuuuube/VoiDPlugins/releases/download/0.5.2/VMultiMode.zip",
     "CompressionFormat": "zip",
-    "SHA256": "a10fbafd1a91ef2d4cc2aa0601c11a876320e5e471119390bd4caaca41945f11",
+    "SHA256": "1efeba0cade9ccb67c9e11dc4c2d38da8304db03ba947a2bc57ea8c2c7470242",
     "WikiUrl": "https://github.com/Kuuuube/VoiDPlugins/wiki/VMultiMode",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.6.0/Kuuuube/VoiDPlugins/WindowsInk.json
+++ b/Repository/0.6.6.0/Kuuuube/VoiDPlugins/WindowsInk.json
@@ -2,12 +2,12 @@
     "Name": "Windows Ink",
     "Owner": "Kuuuube",
     "Description": "Windows Ink Output Mode",
-    "PluginVersion": "0.5.1",
+    "PluginVersion": "0.5.2",
     "SupportedDriverVersion": "0.6.6.0",
     "RepositoryUrl": "https://github.com/Kuuuube/VoiDPlugins",
-    "DownloadUrl": "https://github.com/Kuuuube/VoiDPlugins/releases/download/0.5.1/WindowsInk.zip",
+    "DownloadUrl": "https://github.com/Kuuuube/VoiDPlugins/releases/download/0.5.2/WindowsInk.zip",
     "CompressionFormat": "zip",
-    "SHA256": "5c9444202ae54527c4a9ab1db3284cafd9f2bd526feb60da58b66aa1ba1f8744",
+    "SHA256": "4aa9dc41bcb6e15a388718ef7d46b7518cd0a8b0cc73e89013471c9542b0802f",
     "WikiUrl": "https://github.com/Kuuuube/VoiDPlugins/wiki/WindowsInk",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.6.0/Kuuuube/VoiDPlugins/WindowsPenPointer.json
+++ b/Repository/0.6.6.0/Kuuuube/VoiDPlugins/WindowsPenPointer.json
@@ -1,0 +1,13 @@
+{
+    "Name": "Windows Pen Pointer",
+    "Owner": "Kuuuube",
+    "Description": "Basic Windows Ink Output Mode",
+    "PluginVersion": "0.5.2",
+    "SupportedDriverVersion": "0.6.6.0",
+    "RepositoryUrl": "https://github.com/Kuuuube/VoiDPlugins",
+    "DownloadUrl": "https://github.com/Kuuuube/VoiDPlugins/releases/download/0.5.2/WindowsPenPointer.zip",
+    "CompressionFormat": "zip",
+    "SHA256": "ca511f453405364fb7a07634c8f4de7e0bed81ed9c176ecd5a26dc5fb892be14",
+    "WikiUrl": "https://github.com/Kuuuube/VoiDPlugins/wiki/WindowsPenPointer",
+    "LicenseIdentifier": "GPL-3.0-only"
+}


### PR DESCRIPTION
Windows Pen Pointer is a basic version of windows ink. It doesnt require vmulti but doesn't support all of the features and accuracy. For example, the pressure only goes up to 1024 and it doesnt have subpixel positioning.

VMultiMode now supports using OTD's basic mouse button bindings as passthrough to vmulti bindings. Users that use those by accident arent left with everything broken.

Windows Ink now mostly supports normal mouse buttons. It switches to the normal OS cursor, syncs the position, then sends the mouse button. Any position reports while the button is pressed are sent through the regular OS cursor instead of windows ink. As soon as the mouse button is released, it goes back to normal windows ink.
Some programs don't like this behavior but it works perfectly in most.