### PR TITLE
Update The Saturn Collection to 0.10.3

### DIFF
--- a/Repository/0.6.7.0/shreddism/TheSaturnCollection/TheSaturnCollection.json
+++ b/Repository/0.6.7.0/shreddism/TheSaturnCollection/TheSaturnCollection.json
@@ -1,13 +1,13 @@
 {
     "Name": "The Saturn Collection",
     "Owner": "shreddism",
-    "Description": "The Enhanced Plugin Experience.\n - Configurable antichatter with virtually 0 extra latency\n - Optional interpolation that doesn't mess with filtering\n - Greatly improved prediction and reduced bugs on certain tablets\n - Output mode with realtime area changing and bindable actions\n ...and more!",
-    "PluginVersion": "0.10.0",
+    "Description": "The Enhanced Plugin Experience.\n - Configurable antichatter with virtually 0 extra latency\n - Prediction improvements and bugfixing on certain tablets\n - Massive improvements in the above as well as interpolation timing for Wacom PTK-x70 tablets\n - Output mode with realtime area changing and bindable actions\n ...and more!",   
+    "PluginVersion": "0.10.3",
     "SupportedDriverVersion": "0.6.7",
     "RepositoryUrl": "https://github.com/shreddism/TheSaturnCollection",
-    "DownloadUrl": "https://github.com/shreddism/TheSaturnCollection/releases/download/0.10.0/Saturn.zip",
+    "DownloadUrl": "https://github.com/shreddism/TheSaturnCollection/releases/download/0.10.3/Saturn.zip",
     "CompressionFormat": "zip",
-    "SHA256": "79d03c73529a49d766983342fbbb3e5bdb997f339432401ff0d8ee484040fadf",
+    "SHA256": "a73cf23cfdca1946b37c36d6552a231941531a2ad465d6a311b356bd9b04d5f7",
     "WikiUrl": "https://github.com/shreddism/TheSaturnCollection/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }

--- a/Repository/0.6.7.0/shreddism/TheSaturnCollection/TheSaturnCollection.json
+++ b/Repository/0.6.7.0/shreddism/TheSaturnCollection/TheSaturnCollection.json
@@ -1,7 +1,7 @@
 {
     "Name": "The Saturn Collection",
     "Owner": "shreddism",
-    "Description": "The Enhanced Plugin Experience.\n - Configurable antichatter with virtually 0 extra latency\n - Prediction improvements and bugfixing on certain tablets\n - Massive improvements in the above as well as interpolation timing for Wacom PTK-x70 tablets\n - Output mode with realtime area changing and bindable actions\n ...and more!",   
+    "Description": "The Enhanced Plugin Experience.\n - Configurable antichatter with virtually 0 extra latency\n - Prediction improvements and bugfixing on certain tablets\n - Massive improvements in the above as well as interpolation timing for Wacom PTK-x70 tablets\n - Output mode with realtime area changing and bindable actions\n ...and more!",
     "PluginVersion": "0.10.3",
     "SupportedDriverVersion": "0.6.7",
     "RepositoryUrl": "https://github.com/shreddism/TheSaturnCollection",


### PR DESCRIPTION
notes from [release](https://github.com/shreddism/TheSaturnCollection/releases/tag/0.10.3):
- 0.10.3:
  - Use a trajectory interp curve that doesn't care about even spacing between points on most Wacom tablets (this behaves far more like how a higher report rate tablet would)
  - Fix relative mode not working on PTK-x70, PTH-x60
- 0.10.2:
  - Small fix to 1-report hover antichatter bug with prediction
- 0.10.1:
  - Timing system change for PTK-x70 tablets (Never uses time below 1, far more confident)
  - Slight prediction improvement for PTK-x70 tablets
  - Use a separate Kalman filter that takes velocity for non-jerky movements on any Wacom tablet 200hz or above