### PR TITLE
Update The Saturn Collection to 1.0.0

### DIFF
--- a/Repository/0.6.7.0/shreddism/TheSaturnCollection/TheSaturnCollection.json
+++ b/Repository/0.6.7.0/shreddism/TheSaturnCollection/TheSaturnCollection.json
@@ -2,12 +2,12 @@
     "Name": "The Saturn Collection",
     "Owner": "shreddism",
     "Description": "The Enhanced Plugin Experience.\n - Configurable antichatter with virtually 0 extra latency\n - Prediction improvements and bugfixing on certain tablets\n - Massive improvements in the above as well as interpolation timing for Wacom PTK-x70 tablets\n - Output mode with realtime area changing and bindable actions\n ...and more!",
-    "PluginVersion": "0.10.3",
+    "PluginVersion": "1.0.0",
     "SupportedDriverVersion": "0.6.7",
     "RepositoryUrl": "https://github.com/shreddism/TheSaturnCollection",
-    "DownloadUrl": "https://github.com/shreddism/TheSaturnCollection/releases/download/0.10.3/Saturn.zip",
+    "DownloadUrl": "https://github.com/shreddism/TheSaturnCollection/releases/download/1.0.0/Saturn.zip",
     "CompressionFormat": "zip",
-    "SHA256": "a73cf23cfdca1946b37c36d6552a231941531a2ad465d6a311b356bd9b04d5f7",
+    "SHA256": "97cd17a87563d53f5ee9ce41a197b2664daaf1a0768ac91006c259832ecf7e8c",
     "WikiUrl": "https://github.com/shreddism/TheSaturnCollection/blob/main/README.md",
     "LicenseIdentifier": "GPL-3.0-only"
 }


### PR DESCRIPTION
notes from [release](https://github.com/shreddism/TheSaturnCollection/releases/tag/1.0.0):
- 1.0.0:
  - Add prediction enhancements, bug mitigations for Gaomon S620
  - Add extra multifilter settings tool with:
    - Alternate settings for hover
    - AVX/FMA paths for 4x4 matrix multiplication in the Kalman filter (tested to be faster on my machine)
    - Toggle to disable tablet tweaks placed here
    - All of these are global but opt-in
  - General behavior tweak for Reverse EMA
    - A good setting would still overreact to natural chatter.
    - Now, if the last 2 reported direction lengths are equal to or less than sqrt(2) the setting becomes 1.
    - This is extended for hover on a Gaomon S620 (it certainly has slight hover antichatter)
  - Fix relative mode not working on certain tablets
  - Fix 1-report re-entry bugging on certain tablets
  - Slight prediction tweaks for Wacom PTK-x70